### PR TITLE
[RHPAM-1506] Inconsistent naming of KIE server in RHPAM OpenShift templates

### DIFF
--- a/kieserver/README.adoc
+++ b/kieserver/README.adoc
@@ -1,4 +1,4 @@
-# Red Hat Process Automation Manager Execution Server 7.0 container image
+# Red Hat Process Automation Manager KIE Server 7.0 container image
 
 NOTE: Extends link:https://github.com/jboss-container-images/jboss-eap-7-image[JBoss EAP 7 image]
 

--- a/kieserver/image.yaml
+++ b/kieserver/image.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 name: "rhpam-7/rhpam71-kieserver"
-description: "Red Hat Process Automation Manager Execution Server 7.1 container image"
+description: "Red Hat Process Automation Manager KIE Server 7.1 container image"
 version: "7.1.0"
 from: "jboss-eap-7/eap71:7.1.4"
 labels:

--- a/kieserver/tests/features/kieserver.feature
+++ b/kieserver/tests/features/kieserver.feature
@@ -1,5 +1,5 @@
 @rhpam-7/rhpam71-kieserver
-Feature: RHPAM Standalone Kie Execution Server tests
+Feature: RHPAM Standalone Kie Server tests
 
   Scenario: Test REST API is secure
     When container is ready


### PR DESCRIPTION
[RHPAM-1506] Inconsistent naming of KIE server in RHPAM OpenShift templates
https://issues.jboss.org/browse/RHPAM-1506

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
