### PR TITLE
[KIECLOUD-20] final move to EAP_720 tags

### DIFF
--- a/businesscentral-monitoring/dev-overrides.yaml
+++ b/businesscentral-monitoring/dev-overrides.yaml
@@ -9,4 +9,4 @@ modules:
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-                  ref: EAP72-CR5
+                  ref: EAP_720

--- a/businesscentral-monitoring/rel-overrides.yaml
+++ b/businesscentral-monitoring/rel-overrides.yaml
@@ -9,4 +9,4 @@ modules:
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-                  ref: eap72
+                  ref: EAP_720

--- a/businesscentral/dev-overrides.yaml
+++ b/businesscentral/dev-overrides.yaml
@@ -9,4 +9,4 @@ modules:
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-                  ref: EAP72-CR5
+                  ref: EAP_720

--- a/businesscentral/rel-overrides.yaml
+++ b/businesscentral/rel-overrides.yaml
@@ -9,4 +9,4 @@ modules:
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-                  ref: eap72
+                  ref: EAP_720

--- a/controller/dev-overrides.yaml
+++ b/controller/dev-overrides.yaml
@@ -9,4 +9,4 @@ modules:
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-                  ref: EAP72-CR5
+                  ref: EAP_720

--- a/controller/rel-overrides.yaml
+++ b/controller/rel-overrides.yaml
@@ -9,4 +9,4 @@ modules:
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-                  ref: eap72
+                  ref: EAP_720

--- a/kieserver/dev-overrides.yaml
+++ b/kieserver/dev-overrides.yaml
@@ -9,4 +9,4 @@ modules:
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-                  ref: EAP72-CR5
+                  ref: EAP_720

--- a/kieserver/rel-overrides.yaml
+++ b/kieserver/rel-overrides.yaml
@@ -9,4 +9,4 @@ modules:
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-                  ref: eap72
+                  ref: EAP_720


### PR DESCRIPTION
[KIECLOUD-20] final move to EAP_720 tags, which are identical to EAP72_CR5 tag in jboss-eap-7-image and EAP72_CR5-1 tag in jboss-eap-modules
https://issues.jboss.org/browse/KIECLOUD-20

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
