### PR TITLE
[RHPAM-3805] - Missing kie dependencies in Kie Server ocp image

### DIFF
--- a/kieserver/modules/kieserver/install
+++ b/kieserver/modules/kieserver/install
@@ -25,7 +25,16 @@ if [[ -f "${SOURCES_DIR}/${BUSINESS_CENTRAL_DISTRIBUTION_ZIP}" ]] && [[ "${JBPM_
     fi
 fi
 
-chown -R jboss:root ${JBOSS_HOME}
-chmod 0755 ${JBOSS_HOME}
-chmod -R g+rwX ${JBOSS_HOME}
+# Dir for optional deps
+mkdir -p /opt/kie/dependencies/{jbpm-clustering,jbpm-kafka}
+
+cp ${SOURCES_DIR}/jbpm-event-emitters-kafka-*.jar /opt/kie/dependencies/jbpm-kafka/
+cp ${SOURCES_DIR}/kie-server-services-jbpm-cluster-*.jar /opt/kie/dependencies/jbpm-clustering/
+
+# Necessary to permit running with a randomised UID
+for dir in ${JBOSS_HOME} /opt/kie; do
+    chown -R jboss:root ${dir}
+    chmod 0755 ${dir}
+    chmod -R g+rwX ${dir}
+done
 

--- a/kieserver/modules/kieserver/module.yaml
+++ b/kieserver/modules/kieserver/module.yaml
@@ -37,10 +37,8 @@ artifacts:
   # slf4j-simple-1.7.22.redhat-2.jar
   md5: "62cc6eeb72e2738e3acc8957ca95f37b"
 - name: "kie-server-services-jbpm-cluster-7.52.0.Final-redhat-00008.jar"
-  dest: "/opt/kie/dependencies/jbpm-clustering"
   md5: "f5d788195957937ef2bf9a1a58561f96"
 - name: "jbpm-event-emitters-kafka-7.52.0.Final-redhat-00008.jar"
-  dest: "/opt/kie/dependencies/jbpm-kafka"
   md5: "19a21e71a4f1ed33aea5e1dd682efe9c"
 run:
   user: 185


### PR DESCRIPTION
Signed-off-by: spolti <fspolti@redhat.com>
See: https://issues.redhat.com/browse/RHPAM-3805

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
