### PR TITLE
[RHPAM-5145] Workaround fix: CVE-2025-58713 /etc/passwd permissions c…

### DIFF
--- a/businesscentral-monitoring/modules/businesscentral-monitoring/install
+++ b/businesscentral-monitoring/modules/businesscentral-monitoring/install
@@ -2,6 +2,8 @@
 
 set -e
 
+chmod 644 /etc/passwd
+
 SOURCES_DIR=/tmp/artifacts
 
 unzip -q ${SOURCES_DIR}/${BUSINESS_CENTRAL_MONITORING_DISTRIBUTION_ZIP} -d ${SOURCES_DIR}

--- a/businesscentral/modules/businesscentral/install
+++ b/businesscentral/modules/businesscentral/install
@@ -2,6 +2,8 @@
 
 set -e
 
+chmod 644 /etc/passwd
+
 SOURCES_DIR=/tmp/artifacts
 
 unzip -q ${SOURCES_DIR}/${BUSINESS_CENTRAL_DISTRIBUTION_ZIP} -d ${SOURCES_DIR}

--- a/controller/modules/controller/install
+++ b/controller/modules/controller/install
@@ -2,6 +2,8 @@
 
 set -e
 
+chmod 644 /etc/passwd
+
 SOURCES_DIR=/tmp/artifacts
 
 unzip -q ${SOURCES_DIR}/${ADD_ONS_DISTRIBUTION_ZIP} -d ${SOURCES_DIR}

--- a/dashbuilder/modules/dashbuilder/install
+++ b/dashbuilder/modules/dashbuilder/install
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+chmod 644 /etc/passwd
+
 SOURCES_DIR=/tmp/artifacts
 
 unzip -q ${SOURCES_DIR}/${ADD_ONS_DISTRIBUTION_ZIP} -d ${SOURCES_DIR}

--- a/kieserver/modules/kieserver/install
+++ b/kieserver/modules/kieserver/install
@@ -2,6 +2,8 @@
 
 set -e
 
+chmod 644 /etc/passwd
+
 SOURCES_DIR=/tmp/artifacts
 
 DISTRIBUTION_ZIP=${KIE_SERVER_DISTRIBUTION_ZIP}

--- a/process-migration/modules/process-migration/install
+++ b/process-migration/modules/process-migration/install
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+chmod 644 /etc/passwd
+
 SOURCES_DIR=/tmp/artifacts
 PROCESS_MIGRATION_DIR=/opt/${JBOSS_PRODUCT}
 

--- a/smartrouter/modules/smartrouter/install
+++ b/smartrouter/modules/smartrouter/install
@@ -2,6 +2,8 @@
 
 set -e
 
+chmod 644 /etc/passwd
+
 SOURCES_DIR=/tmp/artifacts
 ROUTER_DIR=/opt/${JBOSS_PRODUCT}
 


### PR DESCRIPTION
…hange

The /etc/passwd file is originally created in cct module - https://github.com/jboss-openshift/cct_module/blob/0.39.x/jboss/container/user/configure.sh and this install step in our images run after during the image build process

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
